### PR TITLE
refactor: Target Quarto Wizard v2 extension schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Target the Quarto Wizard v2 extension schema in `_schema.yml`.
+
 ## 1.2.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -9,7 +9,7 @@
 #   spotlight:
 #     size: 60
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   size:


### PR DESCRIPTION
Points `_schema.yml` at the Quarto Wizard v2 meta-schema. v2 uses JSON Schema 2020-12 canonical names exclusively and validates the file strictly, so editor completion and diagnostics match what the extension accepts. The file validates against v2 unchanged.