### PR TITLE
docs: substitute the placeholders in the sync script

### DIFF
--- a/docs/_scripts/sync-extension.sh
+++ b/docs/_scripts/sync-extension.sh
@@ -3,9 +3,9 @@
 # Documentation Extension Sync
 # Mirrors the repository's own extension into the documentation project.
 #
-# @license %%license%%
-# @copyright %%year%% %%author%%
-# @author %%author%%
+# @license MIT License
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
 #
 # The website demonstrates the extension it documents, so the extension has to
 # be resolvable from docs/. Quarto builds its extension registry while reading


### PR DESCRIPTION
The documentation scaffolder wrote `%%license%%`, `%%year%%` and `%%author%%` into the header of `docs/_scripts/sync-extension.sh` and never replaced them. Its guard grepped only the file types the substitution did not write to, so a `.sh` file that kept its placeholders still passed at exit 0. The scaffolder itself was corrected earlier; this repository is one of the eight that still carried the result.

The three header lines now read the values this repository declares: MIT License, 2026, Mickaël Canouil.

Three comment lines change and nothing else, so the commit carries `[skip ci]`.